### PR TITLE
Untitled

### DIFF
--- a/js/Terminal.js
+++ b/js/Terminal.js
@@ -243,7 +243,7 @@ lang.extend(WireIt.TerminalProxy, util.DDProxy, {
       if(this.terminal.container) {
          var obj = this.terminal.container.layer.el;
          var curleft = curtop = 0;
-        	if (obj.offsetParent) {
+        	if (!obj.offsetParent) {
         		do {
         			curleft += obj.offsetLeft;
         			curtop += obj.offsetTop;


### PR DESCRIPTION
I had the same problem like in the issue #43. When I put ! in front of obj.offsetParent in if statement the wires are drawn while dragging and no error is shown in my console. It's weird but it's working.
